### PR TITLE
report task uses a warning instead of an error for parent pom

### DIFF
--- a/src/main/scala/org/scoverage/maven/ReportMojo.scala
+++ b/src/main/scala/org/scoverage/maven/ReportMojo.scala
@@ -34,7 +34,7 @@ class ReportMojo extends AbstractMojo {
 
     val coverageFile = IOUtils.coverageFile(dataDir)
     if (!coverageFile.exists()) {
-       getLog.info(s"[scoverage] Logfile ${coverageFile.getAbsoluteFile} doesn't exist. Skipping report generation...")
+       getLog.info(s"[scoverage] ${coverageFile.getAbsoluteFile} doesn't exist. Skipping report generation...")
     } else {
        val coverage = IOUtils.deserialize(coverageFile)
 


### PR DESCRIPTION
Hi, 
I implemented a warn message instead of an hard error when creating a scoverage report without the appropriate data file. This is also useful in a multi module build when the parent pom had no coverage data.
