### PR TITLE
Changed dataDir to a string to prevent throw

### DIFF
--- a/src/main/scala/org/scoverage/maven/ReportMojo.scala
+++ b/src/main/scala/org/scoverage/maven/ReportMojo.scala
@@ -29,7 +29,7 @@ class ReportMojo extends AbstractMojo {
 
     val coberturaDir = new File(project.getBasedir + "/target/coverage-report")
     val reportsDir = new File(project.getBasedir + "/target/scoverage-report")
-    val dataDir = new File(project.getBasedir + "/target")
+    val dataDir = project.getBasedir + "/target"
     val classesDir = new File(project.getBuild.getOutputDirectory)
 
     val coverageFile = IOUtils.coverageFile(dataDir)


### PR DESCRIPTION
If dataDir is a File then it throws before the .exists() check takes place, which means that any modules without a coverage file causes the build to fail. This appeared to be the simplest fix.

I ran into this issue using child modules and the parent module has no code and therefore no coverage file.
