### PR TITLE
"Coverage is above minimum" message fixed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ pom.xml.releaseBackup
 pom.xml.versionsBackup
 pom.xml.next
 release.properties
+.idea/
+*.iml

--- a/src/main/java/org/scoverage/plugin/SCoverageCheckMojo.java
+++ b/src/main/java/org/scoverage/plugin/SCoverageCheckMojo.java
@@ -158,7 +158,7 @@ public class SCoverageCheckMojo
             }
             else if ( minimumCoverage > coverage.statementCoveragePercent() )
             {
-                getLog().error( String.format( "[scoverage] Coverage is below minimum [%s%% < %f%%]",
+                getLog().error( String.format( "[scoverage] Coverage is below minimum [%s%% < %.2f%%]",
                                                coverage.statementCoverageFormatted(), minimumCoverage ) );
                 if ( failOnMinimumCoverage )
                 {
@@ -167,7 +167,7 @@ public class SCoverageCheckMojo
             }
             else
             {
-                getLog().info( String.format( "[scoverage] Coverage is above minimum [%s%% < %f%%]",
+                getLog().info( String.format( "[scoverage] Coverage is above minimum [%s%% > %.2f%%]",
                                               coverage.statementCoverageFormatted(), minimumCoverage ) );
             }
         }


### PR DESCRIPTION
Just some minor updates.

"Coverage is above minimum [93.19% < 80.000000%]" was being displayed (notice less than symbol).
Formatting of minimum coverage value restricted to two decimal places.
IntelliJ files added to .gitignore