### PR TITLE
Support multiple source roots in report generators

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@ under the License.
         <maven.version>2.2.1</maven.version>
         <maven-plugin-plugin.version>3.3</maven-plugin-plugin.version>
 
-        <scalac-scoverage-plugin.version>1.0.4</scalac-scoverage-plugin.version>
+        <scalac-scoverage-plugin.version>1.0.5-SNAPSHOT</scalac-scoverage-plugin.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
This PR should be applied (or used for testing) after scoverage/scalac-scoverage-plugin#109. It passes to scalac-scoverage-plugin all source root directories (`project.getExecutionProject().getCompileSourceRoots()`) instead of only `project.getBuild().getSourceDirectory()` or `project.getBasedir()`.