### PR TITLE
Aggregate raw coverage data instead of scoverage XML reports

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,13 +90,13 @@ under the License.
         <maven.version>2.2.1</maven.version>
         <maven-plugin-plugin.version>3.5</maven-plugin-plugin.version>
 
-        <scalac-scoverage-plugin.version>1.3.0</scalac-scoverage-plugin.version>
+        <scalac-scoverage-plugin.version>1.4.0-SNAPSHOT</scalac-scoverage-plugin.version>
     </properties>
 
     <dependencies>
         <dependency>
             <groupId>org.scoverage</groupId>
-            <artifactId>scalac-scoverage-plugin_2.10</artifactId>
+            <artifactId>scalac-scoverage-plugin_2.12</artifactId>
             <version>${scalac-scoverage-plugin.version}</version>
         </dependency>
 

--- a/src/main/java/org/scoverage/plugin/SCoverageCheckMojo.java
+++ b/src/main/java/org/scoverage/plugin/SCoverageCheckMojo.java
@@ -18,6 +18,7 @@
 package org.scoverage.plugin;
 
 import java.io.File;
+import java.util.Arrays;
 import java.util.List;
 
 import org.apache.maven.plugin.AbstractMojo;
@@ -28,7 +29,7 @@ import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
 
-import scala.Predef$;
+import scala.collection.JavaConverters;
 
 import scoverage.Coverage;
 import scoverage.IOUtils;
@@ -147,8 +148,8 @@ public class SCoverageCheckMojo
         }
 
         Coverage coverage = Serializer.deserialize( coverageFile );
-        File[] measurementFiles = IOUtils.findMeasurementFiles( dataDirectory );
-        scala.collection.Set<Object> measurements = IOUtils.invoked( Predef$.MODULE$.wrapRefArray( measurementFiles ) );
+        List<File> measurementFiles = Arrays.asList( IOUtils.findMeasurementFiles( dataDirectory ) );
+        scala.collection.Set<Object> measurements = IOUtils.invoked( JavaConverters.asScalaBuffer( measurementFiles ) );
         coverage.apply( measurements );
 
         int branchCount = coverage.branchCount();


### PR DESCRIPTION
This change is closely related to scoverage/scalac-scoverage-plugin#241

There is no requirement to generate individual coverage reports for modules before generating aggregated report anymore.