### PR TITLE
#41 - Fix 'test' and 'integration-test' mojos.

### DIFF
--- a/src/main/java/org/scoverage/plugin/SCoverageIntegrationTestMojo.java
+++ b/src/main/java/org/scoverage/plugin/SCoverageIntegrationTestMojo.java
@@ -21,6 +21,10 @@ import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugins.annotations.Execute;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.project.MavenProject;
+
+import java.util.List;
 
 /**
  * Executes forked {@code scoverage} life cycle up to {@code vefiry} phase.
@@ -40,11 +44,50 @@ public class SCoverageIntegrationTestMojo
 {
 
     /**
+     * Allows SCoverage to be skipped.
+     * <br>
+     *
+     * @since 1.0.0
+     */
+    @Parameter( property = "scoverage.skip", defaultValue = "false" )
+    private boolean skip;
+
+    /**
+     * Maven project to interact with.
+     */
+    @Parameter( defaultValue = "${project}", readonly = true, required = true )
+    private MavenProject project;
+
+    /**
+     * All Maven projects in the reactor.
+     */
+    @Parameter( defaultValue = "${reactorProjects}", required = true, readonly = true )
+    private List<MavenProject> reactorProjects;
+
+    /**
      * Executes {@code verify} phase in forked {@code scoverage} life cycle.
      */
     @Override
     public void execute()
     {
+        if ( "pom".equals( project.getPackaging() ) )
+        {
+            getLog().info( "Skipping SCoverage execution for project with packaging type 'pom'" );
+            return;
+        }
+
+        if ( skip )
+        {
+            getLog().info( "Skipping Scoverage execution" );
+            return;
+        }
+
+        long ts = System.currentTimeMillis();
+
+        SCoverageForkedLifecycleConfigurator.afterForkedLifecycleExit( project, reactorProjects );
+
+        long te = System.currentTimeMillis();
+        getLog().debug( String.format( "Mojo execution time: %d ms", te - ts ) );
     }
 
 }

--- a/src/main/java/org/scoverage/plugin/SCoverageTestMojo.java
+++ b/src/main/java/org/scoverage/plugin/SCoverageTestMojo.java
@@ -21,6 +21,10 @@ import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugins.annotations.Execute;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.project.MavenProject;
+
+import java.util.List;
 
 /**
  * Executes forked {@code scoverage} life cycle up to {@code test} phase.
@@ -40,11 +44,50 @@ public class SCoverageTestMojo
 {
 
     /**
+     * Allows SCoverage to be skipped.
+     * <br>
+     *
+     * @since 1.0.0
+     */
+    @Parameter( property = "scoverage.skip", defaultValue = "false" )
+    private boolean skip;
+
+    /**
+     * Maven project to interact with.
+     */
+    @Parameter( defaultValue = "${project}", readonly = true, required = true )
+    private MavenProject project;
+
+    /**
+     * All Maven projects in the reactor.
+     */
+    @Parameter( defaultValue = "${reactorProjects}", required = true, readonly = true )
+    private List<MavenProject> reactorProjects;
+
+    /**
      * Executes {@code test} phase in forked {@code scoverage} life cycle.
      */
     @Override
     public void execute()
     {
+        if ( "pom".equals( project.getPackaging() ) )
+        {
+            getLog().info( "Skipping SCoverage execution for project with packaging type 'pom'" );
+            return;
+        }
+
+        if ( skip )
+        {
+            getLog().info( "Skipping Scoverage execution" );
+            return;
+        }
+
+        long ts = System.currentTimeMillis();
+
+        SCoverageForkedLifecycleConfigurator.afterForkedLifecycleExit( project, reactorProjects );
+
+        long te = System.currentTimeMillis();
+        getLog().debug( String.format( "Mojo execution time: %d ms", te - ts ) );
     }
 
 }


### PR DESCRIPTION
`SCoverageForkedLifecycleConfigurator.afterForkedLifecycleExit` method must be always executed after forked life cycle to revert changes introduced by `SCoverageForkedLifecycleConfigurator.afterForkedLifecycleEnter` method executed by `scoverage:pre-compile` mojo.