### PR TITLE
#70 - Scala 2.13.0-M5 support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,7 +90,7 @@ under the License.
         <maven.version>2.2.1</maven.version>
         <maven-plugin-plugin.version>3.6.0</maven-plugin-plugin.version>
 
-        <scalac-scoverage-plugin.version>1.4.0-SNAPSHOT</scalac-scoverage-plugin.version>
+        <scalac-scoverage-plugin.version>1.4.0-M5</scalac-scoverage-plugin.version>
     </properties>
 
     <dependencies>

--- a/src/main/java/org/scoverage/plugin/SCoveragePreCompileMojo.java
+++ b/src/main/java/org/scoverage/plugin/SCoveragePreCompileMojo.java
@@ -82,6 +82,7 @@ public class SCoveragePreCompileMojo
      * <li>if specified, and equals {@code 2.10} or starts with {@code 2.10.} - <b>{@code scalac-scoverage-plugin_2.10}</b> will be used</li>
      * <li>if specified, and equals {@code 2.11} or starts with {@code 2.11.} - <b>{@code scalac-scoverage-plugin_2.11}</b> will be used</li>
      * <li>if specified, and equals {@code 2.12} or starts with {@code 2.12.} - <b>{@code scalac-scoverage-plugin_2.12}</b> will be used</li>
+     * <li>if specified, and equals {@code 2.13.0-M5} - <b>{@code scalac-scoverage-plugin_2.13.0-M5}</b> will be used</li>
      * <li>if specified, but does not meet any of the above conditions or if not specified - plugin execution will be skipped</li>
      * </ul>
      * 
@@ -247,6 +248,10 @@ public class SCoveragePreCompileMojo
             else if ( "2.12".equals( resolvedScalaVersion ) || resolvedScalaVersion.startsWith( "2.12." ) )
             {
                 scalaBinaryVersion = "2.12";
+            }
+            else if ( "2.13.0-M5".equals( resolvedScalaVersion ) )
+            {
+                scalaBinaryVersion = "2.13.0-M5";
             }
             else
             {


### PR DESCRIPTION
Use version `1.4.0-M5` of `scalac-scoverage-plugin` dependency (version `1.4.0` is not released yet).

Version `1.4.0-M5` supports Scala version `2.13.0-M5`.