### PR TITLE
Update `scalac-scoverage-plugin` to enable compatibility with Scala 2.12.13+

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,7 +90,7 @@ under the License.
         <maven.version>2.2.1</maven.version>
         <maven-plugin-plugin.version>3.6.0</maven-plugin-plugin.version>
 
-        <scalac-scoverage-plugin.version>1.4.1</scalac-scoverage-plugin.version>
+        <scalac-scoverage-plugin.version>1.4.2</scalac-scoverage-plugin.version>
     </properties>
 
     <dependencies>

--- a/src/main/java/org/scoverage/plugin/SCoverageCheckMojo.java
+++ b/src/main/java/org/scoverage/plugin/SCoverageCheckMojo.java
@@ -29,8 +29,10 @@ import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
 
+import scala.Tuple2;
 import scala.collection.JavaConverters;
 
+import scala.collection.Set;
 import scoverage.Coverage;
 import scoverage.IOUtils;
 import scoverage.Serializer;
@@ -149,7 +151,7 @@ public class SCoverageCheckMojo
 
         Coverage coverage = Serializer.deserialize( coverageFile );
         List<File> measurementFiles = Arrays.asList( IOUtils.findMeasurementFiles( dataDirectory ) );
-        scala.collection.Set<Object> measurements = IOUtils.invoked( JavaConverters.asScalaBuffer( measurementFiles ) );
+        Set<Tuple2<Object, String>> measurements = IOUtils.invoked( JavaConverters.asScalaBuffer( measurementFiles ) );
         coverage.apply( measurements );
 
         int branchCount = coverage.branchCount();

--- a/src/main/java/org/scoverage/plugin/SCoverageReportMojo.java
+++ b/src/main/java/org/scoverage/plugin/SCoverageReportMojo.java
@@ -44,9 +44,11 @@ import org.apache.maven.reporting.MavenReportException;
 import org.codehaus.plexus.util.StringUtils;
 
 import scala.Option;
+import scala.Tuple2;
 import scala.collection.JavaConverters;
 import scala.collection.Seq;
 
+import scala.collection.Set;
 import scoverage.Constants;
 import scoverage.Coverage;
 import scoverage.IOUtils;
@@ -422,7 +424,7 @@ public class SCoverageReportMojo
         getLog().info( String.format( "Reading scoverage measurements [%s*]...",
                                       new File( dataDirectory, Constants.MeasurementsPrefix() ).getAbsolutePath() ) );
         List<File> measurementFiles = Arrays.asList( IOUtils.findMeasurementFiles( dataDirectory ) );
-        scala.collection.Set<Object> measurements = IOUtils.invoked( JavaConverters.asScalaBuffer( measurementFiles ) );
+        Set<Tuple2<Object, String>> measurements = IOUtils.invoked( JavaConverters.asScalaBuffer( measurementFiles ) );
         coverage.apply( measurements );
 
         getLog().info( "Generating coverage reports..." );


### PR DESCRIPTION
Hi @D-Roch @gslowikowski @sksamuel,

We're using this plugin and we'd like to update our project to Scala 2.12.13.

When we do so, we have the following error:

```
[2021-02-17T23:18:43.604Z] [ERROR] ## Exception when compiling 96 sources to ...

[2021-02-17T23:18:43.604Z] java.lang.NoSuchMethodError: scala.tools.nsc.Global.reporter()Lscala/tools/nsc/reporters/Reporter;
021-02-17T23:18:43.604Z] scoverage.ScoverageInstrumentationComponent$$anon$1.run(plugin.scala:119)
[2021-02-17T23:18:43.604Z] scala.tools.nsc.Global$Run.compileUnitsInternal(Global.scala:1511)
[2021-02-17T23:18:43.604Z] scala.tools.nsc.Global$Run.compileUnits(Global.scala:1495)
[2021-02-17T23:18:43.604Z] scala.tools.nsc.Global$Run.compileSources(Global.scala:1488)
[2021-02-17T23:18:43.604Z] scala.tools.nsc.Global$Run.compile(Global.scala:1617)
[2021-02-17T23:18:43.604Z] xsbt.CachedCompiler0.run(CompilerInterface.scala:153)
[2021-02-17T23:18:43.604Z] xsbt.CachedCompiler0.run(CompilerInterface.scala:125)
[2021-02-17T23:18:43.604Z] xsbt.CompilerInterface.run(CompilerInterface.scala:39)
[2021-02-17T23:18:43.604Z] sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
[2021-02-17T23:18:43.604Z] sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
[2021-02-17T23:18:43.604Z] sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
[2021-02-17T23:18:43.604Z] java.lang.reflect.Method.invoke(Method.java:498)
[2021-02-17T23:18:43.604Z] sbt.internal.inc.AnalyzingCompiler.call(AnalyzingCompiler.scala:248)
...
```

It's a problem already fixed in `scalac-scoverage-plugin`, we just have to update it in this project. 
It's what I've tried to do in this PR.


Cheers,
Jules