### PR TITLE
Consider scala patch version for scalac-scoverage-plugin

### DIFF
--- a/src/main/java/org/scoverage/plugin/SCoveragePreCompileMojo.java
+++ b/src/main/java/org/scoverage/plugin/SCoveragePreCompileMojo.java
@@ -58,11 +58,11 @@ import org.codehaus.plexus.util.StringUtils;
  * <br>
  * This is internal mojo, executed in forked {@code scoverage} life cycle.
  * <br>
- * 
+ *
  * @author <a href="mailto:gslowikowski@gmail.com">Grzegorz Slowikowski</a>
  * @since 1.0.0
  */
-@Mojo( name = "pre-compile", defaultPhase = LifecyclePhase.GENERATE_RESOURCES ) 
+@Mojo( name = "pre-compile", defaultPhase = LifecyclePhase.GENERATE_RESOURCES )
 public class SCoveragePreCompileMojo
     extends AbstractMojo
 {
@@ -70,7 +70,7 @@ public class SCoveragePreCompileMojo
     /**
      * Allows SCoverage to be skipped.
      * <br>
-     * 
+     *
      * @since 1.0.0
      */
     @Parameter( property = "scoverage.skip", defaultValue = "false" )
@@ -85,7 +85,7 @@ public class SCoveragePreCompileMojo
      * <li>if specified, and equals {@code 2.13} or starts with {@code 2.13.} - <b>{@code scalac-scoverage-plugin_2.13}</b> will be used</li>
      * <li>if specified, but does not meet any of the above conditions or if not specified - plugin execution will be skipped</li>
      * </ul>
-     * 
+     *
      * @since 1.0.0
      */
     @Parameter( property = "scala.version" )
@@ -129,7 +129,7 @@ public class SCoveragePreCompileMojo
     /**
      * See <a href="https://github.com/scoverage/sbt-scoverage#highlighting">https://github.com/scoverage/sbt-scoverage#highlighting</a>.
      * <br>
-     * 
+     *
      * @since 1.0.0
      */
     @Parameter( property = "scoverage.highlighting", defaultValue = "true" )
@@ -202,7 +202,7 @@ public class SCoveragePreCompileMojo
 
     /**
      * Configures project for compilation with SCoverage instrumentation.
-     * 
+     *
      * @throws MojoExecutionException if unexpected problem occurs
      */
     @Override
@@ -293,7 +293,7 @@ public class SCoveragePreCompileMojo
 
         try
         {
-            Artifact pluginArtifact = getScalaScoveragePluginArtifact( scalaBinaryVersion );
+            Artifact pluginArtifact = getScalaScoveragePluginArtifact( scalaBinaryVersion, resolvedScalaVersion );
             Artifact runtimeArtifact = getScalaScoverageRuntimeArtifact( scalaBinaryVersion );
 
             if ( pluginArtifact == null )
@@ -434,7 +434,7 @@ public class SCoveragePreCompileMojo
         }
     }
 
-    private Artifact getScalaScoveragePluginArtifact( String scalaMainVersion )
+    private Artifact getScalaScoveragePluginArtifact( String scalaMainVersion, String resolvedScalaVersion )
         throws ArtifactNotFoundException, ArtifactResolutionException
     {
         Artifact result = null;
@@ -457,9 +457,20 @@ public class SCoveragePreCompileMojo
             }
         }
 
-        result =
-            getResolvedArtifact( "org.scoverage", "scalac-scoverage-plugin_" + scalaMainVersion,
-                                 resolvedScalacPluginVersion );
+        try
+        {
+            // Look for plugin artifact matching the scala version (full form like 2.12.14)
+            // If not found then look for artifact based on major version like 2.12
+            result =
+                    getResolvedArtifact( "org.scoverage", "scalac-scoverage-plugin_" + resolvedScalaVersion,
+                            resolvedScalacPluginVersion );
+        } catch (ArtifactNotFoundException e)
+        {
+            result =
+                    getResolvedArtifact( "org.scoverage", "scalac-scoverage-plugin_" + scalaMainVersion,
+                            resolvedScalacPluginVersion );
+        }
+
         return result;
     }
 


### PR DESCRIPTION
This PR implements the approach proposed in #94. Post this it would be possible to use the maven plugin with Scala 2.12.13+

With this PR now plugin artifact lookup logic is done like below

1 First look for artifact having a name like scalac-scoverage-plugin_2.12.14 i.e. use the full version of Scala lib used in the project
2 If that artifact is not found look for scalac-scoverage-plugin_2.12

For this to work completely you still need to specify the scalacPluginVersion property. For example, with Scala 2.12.14 we need version [scalac-scoverage-plugin - 1.4.8](https://github.com/scoverage/scalac-scoverage-plugin/releases/tag/v1.4.8)

Fixes #94

(cherry picked from commit bc925fdf1ae07c333da35b2cb939e8d18df66fab)