### PR TITLE
Improve Scala version resolution

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -246,7 +246,7 @@ under the License.
                     <artifactId>maven-javadoc-plugin</artifactId>
                     <version>3.0.1</version>
                     <configuration>
-                        <source>1.6</source>
+                        <source>1.8</source>
                         <detectJavaApiLink>false</detectJavaApiLink>
                         <subpackages>org.scoverage.plugin</subpackages>
                         <links>
@@ -540,8 +540,8 @@ under the License.
                         <configuration>
                             <rules>
                                 <requireJavaVersion>
-                                    <version>1.6</version>
-                                    <message>Java 1.6 or later required.</message>
+                                    <version>1.8</version>
+                                    <message>Java 1.8 or later required.</message>
                                 </requireJavaVersion>
                             </rules>
                         </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@ under the License.
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.scoverage</groupId>
     <artifactId>scoverage-maven-plugin</artifactId>
-    <version>1.4.2-SNAPSHOT</version>
+    <version>1.4.11-SNAPSHOT</version>
     <packaging>maven-plugin</packaging>
 
     <name>SCoverage Maven Plugin</name>
@@ -90,13 +90,14 @@ under the License.
         <maven.version>2.2.1</maven.version>
         <maven-plugin-plugin.version>3.6.0</maven-plugin-plugin.version>
 
-        <scalac-scoverage-plugin.version>1.4.1</scalac-scoverage-plugin.version>
+        <scalac-scoverage-plugin.version>1.4.11</scalac-scoverage-plugin.version>
+        <scalac-scoverage-plugin.scala.version>2.12.15</scalac-scoverage-plugin.scala.version>
     </properties>
 
     <dependencies>
         <dependency>
             <groupId>org.scoverage</groupId>
-            <artifactId>scalac-scoverage-plugin_2.12</artifactId>
+            <artifactId>scalac-scoverage-plugin_${scalac-scoverage-plugin.scala.version}</artifactId>
             <version>${scalac-scoverage-plugin.version}</version>
         </dependency>
 

--- a/src/main/java/org/scoverage/plugin/SCoverageCheckMojo.java
+++ b/src/main/java/org/scoverage/plugin/SCoverageCheckMojo.java
@@ -29,6 +29,7 @@ import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
 
+import scala.Tuple2;
 import scala.collection.JavaConverters;
 
 import scoverage.Coverage;
@@ -149,7 +150,8 @@ public class SCoverageCheckMojo
 
         Coverage coverage = Serializer.deserialize( coverageFile );
         List<File> measurementFiles = Arrays.asList( IOUtils.findMeasurementFiles( dataDirectory ) );
-        scala.collection.Set<Object> measurements = IOUtils.invoked( JavaConverters.asScalaBuffer( measurementFiles ) );
+        scala.collection.Set<Tuple2<Object, String>> measurements =
+                IOUtils.invoked( JavaConverters.asScalaBuffer( measurementFiles ) );
         coverage.apply( measurements );
 
         int branchCount = coverage.branchCount();

--- a/src/main/java/org/scoverage/plugin/SCoverageReportMojo.java
+++ b/src/main/java/org/scoverage/plugin/SCoverageReportMojo.java
@@ -44,6 +44,7 @@ import org.apache.maven.reporting.MavenReportException;
 import org.codehaus.plexus.util.StringUtils;
 
 import scala.Option;
+import scala.Tuple2;
 import scala.collection.JavaConverters;
 import scala.collection.Seq;
 
@@ -422,7 +423,8 @@ public class SCoverageReportMojo
         getLog().info( String.format( "Reading scoverage measurements [%s*]...",
                                       new File( dataDirectory, Constants.MeasurementsPrefix() ).getAbsolutePath() ) );
         List<File> measurementFiles = Arrays.asList( IOUtils.findMeasurementFiles( dataDirectory ) );
-        scala.collection.Set<Object> measurements = IOUtils.invoked( JavaConverters.asScalaBuffer( measurementFiles ) );
+        scala.collection.Set<Tuple2<Object, String>> measurements =
+                IOUtils.invoked( JavaConverters.asScalaBuffer( measurementFiles ) );
         coverage.apply( measurements );
 
         getLog().info( "Generating coverage reports..." );


### PR DESCRIPTION
Changes:
- upgrade version to `1.4.11-SNAPSHOT` and use `1.4.11` version of `scalac-scoverage-plugin` internally
- improve Scala version resolution logic
