### PR TITLE
Fix NPE during report aggregation when multiple modules are specified using -pl arg

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,8 @@ or
 There is no separate mojo for aggregated reports, there is `aggregate` parameter.
 To additionally generate aggregated SCoverage report for root module, when generating regular reports,
 set `aggregate` parameter value to `true`.
-It works only in multimodule projects.
+It works only in multimodule projects, the aggregated report will be generated in the current
+execution root.
 
 It can be configured by defining `aggregate` plugin configuration parameter or `scoverage.aggregate` project property.
 

--- a/src/it/test_report_for_some_submodules/invoker.properties
+++ b/src/it/test_report_for_some_submodules/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals=clean scoverage:report -e -ntp -pl module01 -pl module02/submodule02_02

--- a/src/it/test_report_for_some_submodules/module01/pom.xml
+++ b/src/it/test_report_for_some_submodules/module01/pom.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <parent>
+        <groupId>it.scoverage-maven-plugin</groupId>
+        <artifactId>test_report_for_some_submodules</artifactId>
+        <version>1.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>module01</artifactId>
+    <name>Test Scoverage report works for specified submodules: Module 1</name>
+
+</project>

--- a/src/it/test_report_for_some_submodules/module01/src/main/scala/pkg01/HelloService1.scala
+++ b/src/it/test_report_for_some_submodules/module01/src/main/scala/pkg01/HelloService1.scala
@@ -1,0 +1,12 @@
+package pkg01
+
+class HelloService1
+{
+  def hello =
+  {
+    "Hello from module 1"
+  }
+
+}
+
+object HelloService1 extends HelloService1

--- a/src/it/test_report_for_some_submodules/module01/src/test/scala/pkg01/HelloServiceTest.scala
+++ b/src/it/test_report_for_some_submodules/module01/src/test/scala/pkg01/HelloServiceTest.scala
@@ -1,0 +1,14 @@
+package pkg01
+
+import org.junit.Test;
+import org.junit.Assert.assertEquals
+
+class HelloServiceTest
+{
+    @Test
+    def test1()
+    {
+        assertEquals("Hello from module 1", HelloService1.hello)
+    }
+
+}

--- a/src/it/test_report_for_some_submodules/module02/pom.xml
+++ b/src/it/test_report_for_some_submodules/module02/pom.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <parent>
+        <groupId>it.scoverage-maven-plugin</groupId>
+        <artifactId>test_report_for_some_submodules</artifactId>
+        <version>1.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>module02</artifactId>
+    <packaging>pom</packaging>
+    <name>Test Scoverage report works for specified submodules: Module 2</name>
+
+    <modules>
+        <module>submodule02_01</module>
+        <module>submodule02_02</module>
+    </modules>
+
+
+</project>

--- a/src/it/test_report_for_some_submodules/module02/submodule02_01/pom.xml
+++ b/src/it/test_report_for_some_submodules/module02/submodule02_01/pom.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <parent>
+        <groupId>it.scoverage-maven-plugin</groupId>
+        <artifactId>module02</artifactId>
+        <version>1.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>submodule02_01</artifactId>
+    <name>Test Scoverage report works for specified submodules: SubModule 2_1</name>
+
+</project>

--- a/src/it/test_report_for_some_submodules/module02/submodule02_01/src/main/scala/pkg02_01/HelloService2.scala
+++ b/src/it/test_report_for_some_submodules/module02/submodule02_01/src/main/scala/pkg02_01/HelloService2.scala
@@ -1,0 +1,12 @@
+package pkg02_01
+
+class HelloService2
+{
+  def hello =
+  {
+    "Hello from submodule02_01"
+  }
+
+}
+
+object HelloService2 extends HelloService2

--- a/src/it/test_report_for_some_submodules/module02/submodule02_01/src/test/scala/pkg02_01/HelloServiceTest.scala
+++ b/src/it/test_report_for_some_submodules/module02/submodule02_01/src/test/scala/pkg02_01/HelloServiceTest.scala
@@ -1,0 +1,14 @@
+package pkg02_01
+
+import org.junit.Test;
+import org.junit.Assert.assertEquals
+
+class HelloServiceTest
+{
+    @Test
+    def test2()
+    {
+        assertEquals("Hello from submodule02_01", HelloService2.hello)
+    }
+
+}

--- a/src/it/test_report_for_some_submodules/module02/submodule02_02/pom.xml
+++ b/src/it/test_report_for_some_submodules/module02/submodule02_02/pom.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <parent>
+        <groupId>it.scoverage-maven-plugin</groupId>
+        <artifactId>module02</artifactId>
+        <version>1.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>submodule02_02</artifactId>
+    <name>Test Scoverage report works for specified submodules: SubModule 2_2</name>
+
+</project>

--- a/src/it/test_report_for_some_submodules/module02/submodule02_02/src/main/scala/pkg02_02/HelloService2.scala
+++ b/src/it/test_report_for_some_submodules/module02/submodule02_02/src/main/scala/pkg02_02/HelloService2.scala
@@ -1,0 +1,12 @@
+package pkg02_02
+
+class HelloService2
+{
+  def hello =
+  {
+    "Hello from submodule02_02"
+  }
+
+}
+
+object HelloService2 extends HelloService2

--- a/src/it/test_report_for_some_submodules/module02/submodule02_02/src/test/scala/pkg02_02/HelloServiceTest.scala
+++ b/src/it/test_report_for_some_submodules/module02/submodule02_02/src/test/scala/pkg02_02/HelloServiceTest.scala
@@ -1,0 +1,14 @@
+package pkg02_02
+
+import org.junit.Test;
+import org.junit.Assert.assertEquals
+
+class HelloServiceTest
+{
+    @Test
+    def test2()
+    {
+        assertEquals("Hello from submodule02_02", HelloService2.hello)
+    }
+
+}

--- a/src/it/test_report_for_some_submodules/pom.xml
+++ b/src/it/test_report_for_some_submodules/pom.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>it.scoverage-maven-plugin</groupId>
+        <artifactId>integration_tests_parent</artifactId>
+        <version>1.0-SNAPSHOT</version>
+        <relativePath>../integration_tests_parent/pom.xml</relativePath>
+    </parent>
+
+    <artifactId>test_report_for_some_submodules</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+    <name>Test Scoverage report works for specified submodules</name>
+    <description>Test Scoverage report works for specified submodules</description>
+
+    <properties>
+        <scala.compat.version>2.13</scala.compat.version>
+        <scala.minor.version>12</scala.minor.version>
+    </properties>
+
+    <modules>
+        <module>module01</module>
+        <module>module02</module>
+    </modules>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>net.alchim31.maven</groupId>
+                <artifactId>scala-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>@project.groupId@</groupId>
+                <artifactId>@project.artifactId@</artifactId>
+                <configuration>
+                    <aggregate>true</aggregate> <!-- for aggregated report -->
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <reporting>
+        <plugins>
+            <plugin>
+                <groupId>@project.groupId@</groupId>
+                <artifactId>@project.artifactId@</artifactId>
+                <configuration>
+                    <aggregate>true</aggregate> <!-- for aggregated report -->
+                </configuration>
+            </plugin>
+        </plugins>
+    </reporting>
+</project>

--- a/src/it/test_report_for_some_submodules/validate.groovy
+++ b/src/it/test_report_for_some_submodules/validate.groovy
@@ -1,0 +1,14 @@
+try {
+
+    def aggregatedScoverageFile = new File(basedir, "target/scoverage.xml")
+    assert aggregatedScoverageFile.exists()
+
+    def aggregatedReportFile = new File(basedir, "target/site/scoverage/index.html")
+    assert aggregatedReportFile.exists()
+
+    return true
+
+} catch (Throwable e) {
+    e.printStackTrace()
+    return false
+}


### PR DESCRIPTION
Fixes #103 

## What changes were proposed in this pull request?

This PR proposes to set `topLevelModule` variable to the current execution root when `topLevelModule` is null. 
We achieve this by traversing upwards in the maven module hierarchy unless we find a module that returns `true` for `module.isExecutionRoot()`.

After this fix, the aggregated report will be available in the current execution root matching the execution behavior of the when `-pl` is not specified.

## Why are the changes needed?

When report aggregation is run against multiple modules are specified using -pl arg, `topLevelModule` is never set to a non-null value since non of the reactor projects return true for `module.isExecutionRoot()`.

## How was this patch tested?

Tested the patch manually on the example mentioned in #103 
