### PR TITLE
Update maven-reporting-api to 3.1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -140,7 +140,7 @@ under the License.
         <dependency>
             <groupId>org.apache.maven.reporting</groupId>
             <artifactId>maven-reporting-api</artifactId>
-            <version>3.0</version>
+            <version>3.1.0</version>
         </dependency>
 
         <dependency>

--- a/src/main/java/org/scoverage/plugin/SCoverageReportMojo.java
+++ b/src/main/java/org/scoverage/plugin/SCoverageReportMojo.java
@@ -29,6 +29,7 @@ import java.util.Locale;
 import java.util.ResourceBundle;
 
 import org.apache.maven.doxia.module.xhtml.decoration.render.RenderingContext;
+import org.apache.maven.doxia.sink.Sink;
 import org.apache.maven.doxia.siterenderer.sink.SiteRendererSink;
 
 import org.apache.maven.plugin.AbstractMojo;
@@ -198,7 +199,7 @@ public class SCoverageReportMojo
     /** {@inheritDoc} */
     @Override
     @SuppressWarnings( "deprecation" )
-    public void generate( org.codehaus.doxia.sink.Sink sink, Locale locale )
+    public void generate( Sink sink, Locale locale )
         throws MavenReportException
     {
         boolean canGenerateNonAggregatedReport = canGenerateNonAggregatedReport();


### PR DESCRIPTION
This bug made a binary incompatible change that breaks all previous versions of this plugin: https://issues.apache.org/jira/browse/MSHARED-1045

The bug has been reproduced [here](https://github.com/andreisilviudragnea/maven-reporting-api-bug).

So updating `maven-reporting-api` version is crucial for having a plugin version which works with: https://github.com/apache/maven-site-plugin/releases/tag/maven-site-plugin-3.11.0

As a side note, this bug would have been caught by a PR opened by dependabot, so please merge #87.