### PR TITLE
Added support for scalac-scoverage-plugin > 2.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -380,7 +380,7 @@ under the License.
                     <configuration>
                         <signature>
                             <groupId>org.codehaus.mojo.signature</groupId>
-                            <artifactId>java16</artifactId>
+                            <artifactId>java18</artifactId>
                             <version>1.0</version>
                         </signature>
                     </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -90,14 +90,14 @@ under the License.
         <maven.version>2.2.1</maven.version>
         <maven-plugin-plugin.version>3.6.0</maven-plugin-plugin.version>
 
-        <scalac-scoverage-plugin.version>1.4.11</scalac-scoverage-plugin.version>
-        <scalac-scoverage-plugin.scala.version>2.12.15</scalac-scoverage-plugin.scala.version>
+        <scalac-scoverage-plugin.version>2.0.7</scalac-scoverage-plugin.version>
+        <scalac-scoverage-plugin.scala.version>2.13</scalac-scoverage-plugin.scala.version>
     </properties>
 
     <dependencies>
         <dependency>
             <groupId>org.scoverage</groupId>
-            <artifactId>scalac-scoverage-plugin_${scalac-scoverage-plugin.scala.version}</artifactId>
+            <artifactId>scalac-scoverage-reporter_${scalac-scoverage-plugin.scala.version}</artifactId>
             <version>${scalac-scoverage-plugin.version}</version>
         </dependency>
 
@@ -264,12 +264,12 @@ under the License.
                             <artifactId>umlgraph</artifactId>
                             <version>5.6.6</version>
                         </docletArtifact>
-                        <additionalparam>
+                        <additionalOptions>
                             -inferrel -inferdep -quiet -hide (java|javax)\..*
                             -collpackages java\.util\..* -qualify
                             -postfixpackage -nodefontsize 9
                             -nodefontpackagesize 7
-                        </additionalparam>
+                        </additionalOptions>
                     </configuration>
                 </plugin>
 

--- a/src/main/java/org/scoverage/plugin/SCoveragePreCompileMojo.java
+++ b/src/main/java/org/scoverage/plugin/SCoveragePreCompileMojo.java
@@ -322,7 +322,7 @@ public class SCoveragePreCompileMojo
             String _scalacPlugins = pluginArtifacts.stream()
                     .map(x -> String.format("%s:%s:%s", x.getGroupId(), x.getArtifactId(),x.getVersion())).collect(Collectors.joining(" "));
 
-            arg = PLUGIN_OPTION + pluginArtifacts.stream().map(x -> x.getFile().getAbsolutePath()).collect(Collectors.joining(":"));
+            arg = PLUGIN_OPTION + pluginArtifacts.stream().map(x -> x.getFile().getAbsolutePath()).collect(Collectors.joining(String.valueOf(java.io.File.pathSeparatorChar)));
             addScalacArgs = addScalacArgs + PIPE + arg;
 
             Properties projectProperties = project.getProperties();

--- a/src/main/java/org/scoverage/plugin/SCoveragePreCompileMojo.java
+++ b/src/main/java/org/scoverage/plugin/SCoveragePreCompileMojo.java
@@ -449,7 +449,7 @@ public class SCoveragePreCompileMojo
         // * Version 1.4.1 older   - 1 artifact, plugin using scalaMainVersion
         //
         final ArtifactVersion pluginArtifactVersion = new DefaultArtifactVersion(resolvedScalacPluginVersion);
-        if(pluginArtifactVersion.getMajorVersion() > 2) {
+        if(pluginArtifactVersion.getMajorVersion() >= 2) {
             List<Artifact> resolvedArtifacts = new ArrayList<>();
             resolvedArtifacts.add(getResolvedArtifact("org.scoverage", "scalac-scoverage-plugin_" + resolvedScalaVersion, resolvedScalacPluginVersion));
             resolvedArtifacts.add(getResolvedArtifact("org.scoverage", "scalac-scoverage-domain_" + scalaMainVersion, resolvedScalacPluginVersion));


### PR DESCRIPTION
Since the 2.0.0 release, scalac-scoverage-plugin has been split into several modules. This has resulted in breaking changes that meant that the scoverage-maven-plugin could not use any version from the v2 series.

This PR implements the changes needed for compatibility with v2 onwards.

The changes are primarily repackaging changes and modifications needed to cope with scoverage no longer using absolute paths.

Reference to the scoverage changes:
https://github.com/scoverage/scalac-scoverage-plugin/issues/368