### PR TITLE
Fix reporting and add a minimal set of it-tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -140,13 +140,13 @@ under the License.
         <dependency>
             <groupId>org.apache.maven.reporting</groupId>
             <artifactId>maven-reporting-api</artifactId>
-            <version>3.1.0</version>
+            <version>3.1.1</version>
         </dependency>
 
         <dependency>
             <groupId>org.apache.maven.doxia</groupId>
             <artifactId>doxia-site-renderer</artifactId>
-            <version>1.0</version>
+            <version>1.11.1</version>
         </dependency>
     </dependencies>
 
@@ -226,7 +226,7 @@ under the License.
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-invoker-plugin</artifactId>
-                    <version>3.1.0</version>
+                    <version>3.6.0</version>
                 </plugin>
 
                 <plugin>
@@ -305,7 +305,7 @@ under the License.
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-project-info-reports-plugin</artifactId>
-                    <version>3.0.0</version>
+                    <version>3.5.0</version>
                 </plugin>
 
                 <plugin>
@@ -332,14 +332,7 @@ under the License.
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-site-plugin</artifactId>
-                    <version>3.7.1</version>
-                    <dependencies>
-                        <dependency>
-                            <groupId>org.apache.maven.doxia</groupId>
-                            <artifactId>doxia-module-markdown</artifactId>
-                            <version>1.8</version>
-                        </dependency>
-                    </dependencies>
+                    <version>3.12.1</version>
                 </plugin>
 
                 <plugin>
@@ -763,6 +756,51 @@ under the License.
                 </plugins>
             </build>
         </profile>
+
+        <profile>
+            <id>integration-tests</id>
+            <activation>
+                <property>
+                    <name>maven.test.skip</name>
+                    <value>!true</value>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-invoker-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <phase>integration-test</phase>
+                                <id>integration-tests</id>
+                                <goals>
+                                    <goal>install</goal>
+                                    <goal>run</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <cloneProjectsTo>${project.build.directory}/it</cloneProjectsTo>
+                            <debug>false</debug>
+                            <streamLogs>true</streamLogs>
+                            <projectsDirectory>src/it</projectsDirectory>
+                            <pomIncludes>
+                                <pomInclude>**/pom.xml</pomInclude>
+                            </pomIncludes>
+                            <pomExcludes>
+                                <pomExclude>**/off-*/pom.xml</pomExclude>
+                                <pomExclude>**/off-*/**/pom.xml</pomExclude>
+                                <pomExclude>**/mi*/pom.xml</pomExclude>
+                                <pomExclude>**/integration_tests_parent/pom.xml</pomExclude>
+                            </pomExcludes>
+                            <preBuildHookScript>setup.groovy</preBuildHookScript>
+                            <postBuildHookScript>validate.groovy</postBuildHookScript>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
     </profiles>
 
 </project>

--- a/src/it/integration_tests_parent/pom.xml
+++ b/src/it/integration_tests_parent/pom.xml
@@ -1,0 +1,144 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>it.scoverage-maven-plugin</groupId>
+    <artifactId>integration_tests_parent</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+    <name>Scoverage Plugin Integration Tests Parent</name>
+    <description>Scoverage Plugin Integration Tests Parent</description>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <junit.version>4.13</junit.version>
+        <scalatest.version>3.2.17</scalatest.version>
+
+        <compiler.plugin.version>3.11.0</compiler.plugin.version>
+        <surefire.plugin.version>3.1.2</surefire.plugin.version>
+        <scala.plugin.version>4.8.1</scala.plugin.version>
+        <scalatest.plugin.version>2.0.0</scalatest.plugin.version>
+        <project-info-reports.plugin.version>3.5.0</project-info-reports.plugin.version>
+        <site.plugin.version>3.12.1</site.plugin.version>
+
+        <scala.compat.version>2.13</scala.compat.version>
+        <scala.minor.version>12</scala.minor.version>
+        <scala.version>${scala.compat.version}.${scala.minor.version}</scala.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.scala-lang</groupId>
+            <artifactId>scala-library</artifactId>
+            <version>${scala.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.scalatest</groupId>
+            <artifactId>scalatest_${scala.compat.version}</artifactId>
+            <version>${scalatest.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <sourceDirectory>src/main/scala</sourceDirectory>
+        <testSourceDirectory>src/test/scala</testSourceDirectory>
+
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>${compiler.plugin.version}</version>
+                    <configuration>
+                        <skipMain>true</skipMain> <!-- skip compile -->
+                        <skip>true</skip> <!-- skip testCompile -->
+                    </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <version>${surefire.plugin.version}</version>
+                </plugin>
+                <plugin>
+                    <groupId>net.alchim31.maven</groupId>
+                    <artifactId>scala-maven-plugin</artifactId>
+                    <version>${scala.plugin.version}</version>
+                    <executions>
+                        <execution>
+                            <id>default-sbt-compile</id>
+                            <goals>
+                                <goal>compile</goal>
+                                <goal>testCompile</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-site-plugin</artifactId>
+                    <version>${site.plugin.version}</version>
+                </plugin>
+                <plugin>
+                    <groupId>@project.groupId@</groupId>
+                    <artifactId>@project.artifactId@</artifactId>
+                    <version>@project.version@</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.scalatest</groupId>
+                    <artifactId>scalatest-maven-plugin</artifactId>
+                    <version>${scalatest.plugin.version}</version>
+                    <executions>
+                        <execution>
+                            <id>test</id>
+                            <phase>test</phase>
+                            <goals>
+                                <goal>test</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
+
+    <reporting>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-project-info-reports-plugin</artifactId>
+                <version>${project-info-reports.plugin.version}</version>
+                <reportSets>
+                    <reportSet>
+                        <reports>
+                            <report>index</report>
+                        </reports>
+                    </reportSet>
+                </reportSets>
+            </plugin>
+
+            <plugin>
+                <groupId>@project.groupId@</groupId>
+                <artifactId>@project.artifactId@</artifactId>
+                <version>@project.version@</version>
+                <reportSets>
+                    <reportSet>
+                        <reports>
+                            <report>report</report> <!-- select only one report from: report, integration-report and report-only reporters -->
+                        </reports>
+                    </reportSet>
+                </reportSets>
+            </plugin>
+        </plugins>
+    </reporting>
+
+</project>

--- a/src/it/test_ScalaMavenPlugin_Scala212_JUnit/invoker.properties
+++ b/src/it/test_ScalaMavenPlugin_Scala212_JUnit/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals=clean verify site -e -ntp

--- a/src/it/test_ScalaMavenPlugin_Scala212_JUnit/pom.xml
+++ b/src/it/test_ScalaMavenPlugin_Scala212_JUnit/pom.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>it.scoverage-maven-plugin</groupId>
+        <artifactId>integration_tests_parent</artifactId>
+        <version>1.0-SNAPSHOT</version>
+        <relativePath>../integration_tests_parent/pom.xml</relativePath>
+    </parent>
+
+    <artifactId>test_ScalaMavenPlugin_Scala212_JUnit</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+    <name>Test Scoverage Report using scala-maven-plugin, Scala 2.12 and JUnit</name>
+    <description>Test Scoverage Report using scala-maven-plugin, Scala 2.12 and JUnit</description>
+
+    <properties>
+        <scala.compat.version>2.12</scala.compat.version>
+        <scala.minor.version>18</scala.minor.version>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>net.alchim31.maven</groupId>
+                <artifactId>scala-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>@project.groupId@</groupId>
+                <artifactId>@project.artifactId@</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/it/test_ScalaMavenPlugin_Scala212_JUnit/src/main/scala/HelloServiceScala.scala
+++ b/src/it/test_ScalaMavenPlugin_Scala212_JUnit/src/main/scala/HelloServiceScala.scala
@@ -1,0 +1,6 @@
+package service
+
+object HelloServiceScala {
+  def hello = { "Hello" }
+
+}

--- a/src/it/test_ScalaMavenPlugin_Scala212_JUnit/src/test/scala/HelloServiceScalaTest.scala
+++ b/src/it/test_ScalaMavenPlugin_Scala212_JUnit/src/test/scala/HelloServiceScalaTest.scala
@@ -1,0 +1,11 @@
+package service
+
+import org.junit.Test;
+import org.junit.Assert.assertEquals
+
+class HelloServiceScalaTest
+{
+    @Test
+    def test1() = assertEquals("Hello", HelloServiceScala.hello)
+
+}

--- a/src/it/test_ScalaMavenPlugin_Scala212_JUnit/validate.groovy
+++ b/src/it/test_ScalaMavenPlugin_Scala212_JUnit/validate.groovy
@@ -1,0 +1,19 @@
+try {
+
+    def logFile = new File(basedir, "build.log")
+    def lines = logFile.readLines()
+    assert lines.contains("[INFO] Statement coverage.: 100.00%")
+    assert lines.contains("[INFO] Branch coverage....: 100.00%")
+
+    def scoverageFile = new File(basedir, "target/scoverage.xml")
+    assert scoverageFile.exists()
+
+    def reportFile = new File(basedir, "target/site/scoverage/index.html")
+    assert reportFile.exists()
+
+    return true
+
+} catch (Throwable e) {
+    e.printStackTrace()
+    return false
+}

--- a/src/it/test_ScalaMavenPlugin_Scala212_ScalaTest/invoker.properties
+++ b/src/it/test_ScalaMavenPlugin_Scala212_ScalaTest/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals=clean verify site -e -ntp

--- a/src/it/test_ScalaMavenPlugin_Scala212_ScalaTest/pom.xml
+++ b/src/it/test_ScalaMavenPlugin_Scala212_ScalaTest/pom.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>it.scoverage-maven-plugin</groupId>
+        <artifactId>integration_tests_parent</artifactId>
+        <version>1.0-SNAPSHOT</version>
+        <relativePath>../integration_tests_parent/pom.xml</relativePath>
+    </parent>
+
+    <artifactId>test_ScalaMavenPlugin_Scala212_ScalaTest</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+    <name>Test Scoverage Report using scala-maven-plugin, Scala 2.12 and ScalaTest</name>
+    <description>Test Scoverage Report using scala-maven-plugin, Scala 2.12 and ScalaTest</description>
+
+    <properties>
+        <scala.compat.version>2.12</scala.compat.version>
+        <scala.minor.version>18</scala.minor.version>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>net.alchim31.maven</groupId>
+                <artifactId>scala-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.scalatest</groupId>
+                <artifactId>scalatest-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>@project.groupId@</groupId>
+                <artifactId>@project.artifactId@</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/it/test_ScalaMavenPlugin_Scala212_ScalaTest/src/main/scala/HelloServiceScala.scala
+++ b/src/it/test_ScalaMavenPlugin_Scala212_ScalaTest/src/main/scala/HelloServiceScala.scala
@@ -1,0 +1,6 @@
+package service
+
+object HelloServiceScala {
+  def hello = { "Hello" }
+
+}

--- a/src/it/test_ScalaMavenPlugin_Scala212_ScalaTest/src/test/scala/HelloServiceScalaTest.scala
+++ b/src/it/test_ScalaMavenPlugin_Scala212_ScalaTest/src/test/scala/HelloServiceScalaTest.scala
@@ -1,0 +1,12 @@
+package service
+
+import org.scalatest.wordspec.AnyWordSpec
+
+class HelloServiceScalaTest extends AnyWordSpec {
+
+  "HelloService" should {
+    "say hello" in {
+      assert(HelloServiceScala.hello == "Hello")
+    }
+  }
+}

--- a/src/it/test_ScalaMavenPlugin_Scala212_ScalaTest/validate.groovy
+++ b/src/it/test_ScalaMavenPlugin_Scala212_ScalaTest/validate.groovy
@@ -1,0 +1,19 @@
+try {
+
+    def logFile = new File(basedir, "build.log")
+    def lines = logFile.readLines()
+    assert lines.contains("[INFO] Statement coverage.: 100.00%")
+    assert lines.contains("[INFO] Branch coverage....: 100.00%")
+
+    def scoverageFile = new File(basedir, "target/scoverage.xml")
+    assert scoverageFile.exists()
+
+    def reportFile = new File(basedir, "target/site/scoverage/index.html")
+    assert reportFile.exists()
+
+    return true
+
+} catch (Throwable e) {
+    e.printStackTrace()
+    return false
+}

--- a/src/it/test_ScalaMavenPlugin_Scala213_JUnit/invoker.properties
+++ b/src/it/test_ScalaMavenPlugin_Scala213_JUnit/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals=clean verify site -e -ntp

--- a/src/it/test_ScalaMavenPlugin_Scala213_JUnit/pom.xml
+++ b/src/it/test_ScalaMavenPlugin_Scala213_JUnit/pom.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>it.scoverage-maven-plugin</groupId>
+        <artifactId>integration_tests_parent</artifactId>
+        <version>1.0-SNAPSHOT</version>
+        <relativePath>../integration_tests_parent/pom.xml</relativePath>
+    </parent>
+
+    <artifactId>test_ScalaMavenPlugin_Scala213_JUnit</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+    <name>Test Scoverage Report using scala-maven-plugin, Scala 2.13 and JUnit</name>
+    <description>Test Scoverage Report using scala-maven-plugin, Scala 2.13 and JUnit</description>
+
+    <properties>
+        <scala.compat.version>2.13</scala.compat.version>
+        <scala.minor.version>12</scala.minor.version>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>net.alchim31.maven</groupId>
+                <artifactId>scala-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>@project.groupId@</groupId>
+                <artifactId>@project.artifactId@</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/it/test_ScalaMavenPlugin_Scala213_JUnit/src/main/scala/HelloServiceScala.scala
+++ b/src/it/test_ScalaMavenPlugin_Scala213_JUnit/src/main/scala/HelloServiceScala.scala
@@ -1,0 +1,6 @@
+package service
+
+object HelloServiceScala {
+  def hello = { "Hello" }
+
+}

--- a/src/it/test_ScalaMavenPlugin_Scala213_JUnit/src/test/scala/HelloServiceScalaTest.scala
+++ b/src/it/test_ScalaMavenPlugin_Scala213_JUnit/src/test/scala/HelloServiceScalaTest.scala
@@ -1,0 +1,11 @@
+package service
+
+import org.junit.Test;
+import org.junit.Assert.assertEquals
+
+class HelloServiceScalaTest
+{
+    @Test
+    def test1() = assertEquals("Hello", HelloServiceScala.hello)
+
+}

--- a/src/it/test_ScalaMavenPlugin_Scala213_JUnit/validate.groovy
+++ b/src/it/test_ScalaMavenPlugin_Scala213_JUnit/validate.groovy
@@ -1,0 +1,19 @@
+try {
+
+    def logFile = new File(basedir, "build.log")
+    def lines = logFile.readLines()
+    assert lines.contains("[INFO] Statement coverage.: 100.00%")
+    assert lines.contains("[INFO] Branch coverage....: 100.00%")
+
+    def scoverageFile = new File(basedir, "target/scoverage.xml")
+    assert scoverageFile.exists()
+
+    def reportFile = new File(basedir, "target/site/scoverage/index.html")
+    assert reportFile.exists()
+
+    return true
+
+} catch (Throwable e) {
+    e.printStackTrace()
+    return false
+}

--- a/src/it/test_ScalaMavenPlugin_Scala213_ScalaTest/invoker.properties
+++ b/src/it/test_ScalaMavenPlugin_Scala213_ScalaTest/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals=clean verify site -e -ntp

--- a/src/it/test_ScalaMavenPlugin_Scala213_ScalaTest/pom.xml
+++ b/src/it/test_ScalaMavenPlugin_Scala213_ScalaTest/pom.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>it.scoverage-maven-plugin</groupId>
+        <artifactId>integration_tests_parent</artifactId>
+        <version>1.0-SNAPSHOT</version>
+        <relativePath>../integration_tests_parent/pom.xml</relativePath>
+    </parent>
+
+    <artifactId>test_ScalaMavenPlugin_Scala213_ScalaTest</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+    <name>Test Scoverage Report using scala-maven-plugin, Scala 2.13 and ScalaTest</name>
+    <description>Test Scoverage Report using scala-maven-plugin, Scala 2.13 and ScalaTest</description>
+
+    <properties>
+        <scala.compat.version>2.13</scala.compat.version>
+        <scala.minor.version>12</scala.minor.version>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>net.alchim31.maven</groupId>
+                <artifactId>scala-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.scalatest</groupId>
+                <artifactId>scalatest-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>@project.groupId@</groupId>
+                <artifactId>@project.artifactId@</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/it/test_ScalaMavenPlugin_Scala213_ScalaTest/src/main/scala/HelloServiceScala.scala
+++ b/src/it/test_ScalaMavenPlugin_Scala213_ScalaTest/src/main/scala/HelloServiceScala.scala
@@ -1,0 +1,6 @@
+package service
+
+object HelloServiceScala {
+  def hello = { "Hello" }
+
+}

--- a/src/it/test_ScalaMavenPlugin_Scala213_ScalaTest/src/test/scala/HelloServiceScalaTest.scala
+++ b/src/it/test_ScalaMavenPlugin_Scala213_ScalaTest/src/test/scala/HelloServiceScalaTest.scala
@@ -1,0 +1,12 @@
+package service
+
+import org.scalatest.wordspec.AnyWordSpec
+
+class HelloServiceScalaTest extends AnyWordSpec {
+
+  "HelloService" should {
+    "say hello" in {
+      assert(HelloServiceScala.hello == "Hello")
+    }
+  }
+}

--- a/src/it/test_ScalaMavenPlugin_Scala213_ScalaTest/validate.groovy
+++ b/src/it/test_ScalaMavenPlugin_Scala213_ScalaTest/validate.groovy
@@ -1,0 +1,19 @@
+try {
+
+    def logFile = new File(basedir, "build.log")
+    def lines = logFile.readLines()
+    assert lines.contains("[INFO] Statement coverage.: 100.00%")
+    assert lines.contains("[INFO] Branch coverage....: 100.00%")
+
+    def scoverageFile = new File(basedir, "target/scoverage.xml")
+    assert scoverageFile.exists()
+
+    def reportFile = new File(basedir, "target/site/scoverage/index.html")
+    assert reportFile.exists()
+
+    return true
+
+} catch (Throwable e) {
+    e.printStackTrace()
+    return false
+}

--- a/src/main/java/org/scoverage/plugin/SCoverageReportMojo.java
+++ b/src/main/java/org/scoverage/plugin/SCoverageReportMojo.java
@@ -29,8 +29,7 @@ import java.util.Locale;
 import java.util.ResourceBundle;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.apache.maven.doxia.module.xhtml.decoration.render.RenderingContext;
-import org.apache.maven.doxia.sink.Sink;
+import org.apache.maven.doxia.siterenderer.RenderingContext;
 import org.apache.maven.doxia.siterenderer.sink.SiteRendererSink;
 
 import org.apache.maven.plugin.AbstractMojo;
@@ -43,6 +42,7 @@ import org.apache.maven.project.MavenProject;
 import org.apache.maven.reporting.MavenReport;
 import org.apache.maven.reporting.MavenReportException;
 
+import org.codehaus.doxia.sink.Sink;
 import org.codehaus.plexus.util.StringUtils;
 
 import scala.Option;


### PR DESCRIPTION
Seems like #105 broke `site` functionality by bumping `maven-reporting-api` to `3.1.0` but leaving incompatible `doxia-site-renderer`.
I was able to run `scoverage:report` in  https://github.com/scoverage/scoverage-maven-samples but not `mvn verify site`.
So this PR does two things:
- fixes `site`functionality by bumping to latest versions of all related artifacts
- adds a small set of integration tests to this repo, to catch issues like that without a need to manually run changes on https://github.com/scoverage/scoverage-maven-samples for each new PR