### PR TITLE
Skip compilation when skip scoverage to speed up build

### DIFF
--- a/src/main/java/org/scoverage/plugin/SCoveragePreCompileMojo.java
+++ b/src/main/java/org/scoverage/plugin/SCoveragePreCompileMojo.java
@@ -219,7 +219,7 @@ public class SCoveragePreCompileMojo
 
             Properties projectProperties = project.getProperties();
 
-            // for  maven-compiler-plugin (compile), scala-maven-plugin (ompile)
+            // for  maven-compiler-plugin (compile), scala-maven-plugin (compile)
             setProperty( projectProperties, "maven.main.skip", "true" );
 
             // for maven-resources-plugin (testResources), maven-compiler-plugin (testCompile),

--- a/src/main/java/org/scoverage/plugin/SCoveragePreCompileMojo.java
+++ b/src/main/java/org/scoverage/plugin/SCoveragePreCompileMojo.java
@@ -219,6 +219,9 @@ public class SCoveragePreCompileMojo
 
             Properties projectProperties = project.getProperties();
 
+            // for  maven-compiler-plugin (compile), scala-maven-plugin (ompile)
+            setProperty( projectProperties, "maven.main.skip", "true" );
+
             // for maven-resources-plugin (testResources), maven-compiler-plugin (testCompile),
             // sbt-compiler-maven-plugin (testCompile), scala-maven-plugin (testCompile),
             // maven-surefire-plugin and scalatest-maven-plugin


### PR DESCRIPTION
Currently, when set `skip` as `true` in the configuration section of scoverage plugin, only `testCompile` and `test` are skipped for plugins like `maven-compiler-plugin` and `scalatest-maven-plugin`.

This PR set `maven.main.skip` as true in project property to skip compilation of main as well to speed up build.