### PR TITLE
Fix `no source root found` issue with Scala 3 for multi-module projects

### DIFF
--- a/src/it/test_Scala3_multimodule/invoker.properties
+++ b/src/it/test_Scala3_multimodule/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals=clean verify site -e -ntp

--- a/src/it/test_Scala3_multimodule/module01/pom.xml
+++ b/src/it/test_Scala3_multimodule/module01/pom.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <parent>
+        <groupId>it.scoverage-maven-plugin</groupId>
+        <artifactId>test_Scala3_multimodule</artifactId>
+        <version>1.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>module01</artifactId>
+    <name>Test Scala 3 Multi-Module: Module 1</name>
+
+</project>

--- a/src/it/test_Scala3_multimodule/module01/src/main/scala/pkg01/HelloService1.scala
+++ b/src/it/test_Scala3_multimodule/module01/src/main/scala/pkg01/HelloService1.scala
@@ -1,0 +1,12 @@
+package pkg01
+
+class HelloService1
+{
+  def hello: String =
+  {
+    "Hello from module 1"
+  }
+
+}
+
+object HelloService1 extends HelloService1

--- a/src/it/test_Scala3_multimodule/module01/src/test/scala/pkg01/HelloServiceTest.scala
+++ b/src/it/test_Scala3_multimodule/module01/src/test/scala/pkg01/HelloServiceTest.scala
@@ -1,0 +1,14 @@
+package pkg01
+
+import org.junit.Test;
+import org.junit.Assert.assertEquals
+
+class HelloServiceTest
+{
+    @Test
+    def test1(): Unit =
+    {
+        assertEquals("Hello from module 1", HelloService1.hello)
+    }
+
+}

--- a/src/it/test_Scala3_multimodule/pom.xml
+++ b/src/it/test_Scala3_multimodule/pom.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>it.scoverage-maven-plugin</groupId>
+        <artifactId>integration_tests_parent</artifactId>
+        <version>1.0-SNAPSHOT</version>
+        <relativePath>../integration_tests_parent/pom.xml</relativePath>
+    </parent>
+
+    <artifactId>test_Scala3_multimodule</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+    <name>Test Scala 3 Multi-Module</name>
+    <description>Test Scala 3 Multi-Module</description>
+
+    <properties>
+        <scala.compat.version>3</scala.compat.version>
+        <scala.version>3.3.1</scala.version>
+        <scala.library.artifact.id>scala3-library_3</scala.library.artifact.id>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <modules>
+        <module>module01</module>
+    </modules>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>net.alchim31.maven</groupId>
+                <artifactId>scala-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>@project.groupId@</groupId>
+                <artifactId>@project.artifactId@</artifactId>
+                <configuration>
+                    <aggregate>true</aggregate> <!-- for aggregated report -->
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <reporting>
+        <plugins>
+            <plugin>
+                <groupId>@project.groupId@</groupId>
+                <artifactId>@project.artifactId@</artifactId>
+                <configuration>
+                    <aggregate>true</aggregate> <!-- for aggregated report -->
+                </configuration>
+            </plugin>
+        </plugins>
+    </reporting>
+</project>

--- a/src/it/test_Scala3_multimodule/validate.groovy
+++ b/src/it/test_Scala3_multimodule/validate.groovy
@@ -1,0 +1,20 @@
+try {
+
+    def module1ScoverageFile = new File(basedir, "module01/target/scoverage.xml")
+    assert module1ScoverageFile.exists()
+
+    def module1ReportFile = new File(basedir, "module01/target/site/scoverage/index.html")
+    assert module1ReportFile.exists()
+
+    def aggregatedScoverageFile = new File(basedir, "target/scoverage.xml")
+    assert aggregatedScoverageFile.exists()
+
+    def aggregatedReportFile = new File(basedir, "target/site/scoverage/index.html")
+    assert aggregatedReportFile.exists()
+
+    return true
+
+} catch (Throwable e) {
+    e.printStackTrace()
+    return false
+}

--- a/src/main/java/org/scoverage/plugin/SCoveragePreCompileMojo.java
+++ b/src/main/java/org/scoverage/plugin/SCoveragePreCompileMojo.java
@@ -33,6 +33,7 @@ import org.apache.maven.artifact.resolver.ArtifactResolutionException;
 import org.apache.maven.artifact.resolver.ArtifactResolver;
 import org.apache.maven.artifact.versioning.ArtifactVersion;
 import org.apache.maven.artifact.versioning.DefaultArtifactVersion;
+import org.apache.maven.execution.MavenSession;
 import org.apache.maven.model.Dependency;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
@@ -154,6 +155,12 @@ public class SCoveragePreCompileMojo
      */
     @Parameter( defaultValue = "${project}", readonly = true, required = true )
     private MavenProject project;
+
+    /**
+     * The current Maven session.
+     */
+    @Parameter( defaultValue = "${session}", readonly = true, required = true )
+    private MavenSession session;
 
     /**
      * All Maven projects in the reactor.
@@ -283,7 +290,7 @@ public class SCoveragePreCompileMojo
             String _scalacOptions = quoteArgument( arg );
             String addScalacArgs = arg;
 
-            arg = scala2 ? ( SOURCE_ROOT_OPTION + project.getBasedir().getAbsolutePath() ) : "";
+            arg = scala2 ? ( SOURCE_ROOT_OPTION + session.getExecutionRootDirectory() ) : "";
             _scalacOptions = _scalacOptions + SPACE + quoteArgument( arg );
             addScalacArgs = addScalacArgs + PIPE + arg;
 


### PR DESCRIPTION
fixes #191 

This sets source root relative to the top-level project, not the current project.
This matches what Scala 3 compiler emits by default.