### PR TITLE
Fix typo in javadoc

### DIFF
--- a/src/main/java/org/scoverage/plugin/SCoverageIntegrationTestMojo.java
+++ b/src/main/java/org/scoverage/plugin/SCoverageIntegrationTestMojo.java
@@ -27,7 +27,7 @@ import org.apache.maven.project.MavenProject;
 import java.util.List;
 
 /**
- * Executes forked {@code scoverage} life cycle up to {@code vefiry} phase.
+ * Executes forked {@code scoverage} life cycle up to {@code verify} phase.
  * <br>
  * <br>
  * In forked {@code scoverage} life cycle project is compiled with SCoverage instrumentation


### PR DESCRIPTION
## Motivation
 
I noticed the typo when reading the docs at http://scoverage.github.io/scoverage-maven-plugin/2.0.5/integration-test-mojo.html and http://scoverage.github.io/scoverage-maven-plugin/2.0.5/plugin-info.html#
 
 ## Checklist
 - [N/A] Add/Update integration tests in src/it
 - [N/A] Add/Update documentation in README
