### PR TITLE
Don't compile main sources in `scoverage` lifecycle when `skip` is set

### DIFF
--- a/src/it/test_skip_configured/invoker.properties
+++ b/src/it/test_skip_configured/invoker.properties
@@ -1,1 +1,1 @@
-invoker.goals=clean verify site -e -ntp
+invoker.goals=clean scoverage:check site -e -ntp

--- a/src/it/test_skip_configured/validate.groovy
+++ b/src/it/test_skip_configured/validate.groovy
@@ -5,6 +5,12 @@ try {
     assert lines.contains("[INFO] Skipping Scoverage execution as configured")
     assert !lines.contains("Generating \"SCoverage\" report")
 
+    // let's check main code is also not compiled
+    def scalaMainSourcesCompilerInfoIndex = lines.findIndexOf { it ==~ /.*:compile \(default-sbt-compile\).*/ } + 1
+    def scalaMainSourcesCompilerInfo = lines.get(scalaMainSourcesCompilerInfoIndex)
+    def expectedInfo = "[INFO] Not compiling main sources"
+    assert scalaMainSourcesCompilerInfo.contains(expectedInfo) : "Expected '$expectedInfo' but got: '$scalaMainSourcesCompilerInfo'"
+
     return true
 
 } catch (Throwable e) {

--- a/src/main/java/org/scoverage/plugin/SCoveragePreCompileMojo.java
+++ b/src/main/java/org/scoverage/plugin/SCoveragePreCompileMojo.java
@@ -201,6 +201,9 @@ public class SCoveragePreCompileMojo
 
             Properties projectProperties = project.getProperties();
 
+            // for  maven-compiler-plugin (compile), scala-maven-plugin (compile)
+            setProperty( projectProperties, "maven.main.skip", "true" );
+
             // for maven-resources-plugin (testResources), maven-compiler-plugin (testCompile),
             // scala-maven-plugin (testCompile), maven-surefire-plugin and scalatest-maven-plugin
             setProperty( projectProperties, "maven.test.skip", "true" );


### PR DESCRIPTION
## Motivation
 
 Explain the why of this pull request.
 
 ## Checklist
 - [ ] Add/Update integration tests in src/it
 - [ ] Add/Update documentation in README
